### PR TITLE
allow batch enqueueing of jobs using Redis Pipelining

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ worker.end(true);
 try { workerThread.join(); } catch (Exception e){ e.printStackTrace(); }
 ```
 
+If enqueueing multiple jobs at the same time, there is `client.batchEnqueue(String queue, List<Job> jobs)` which does it
+in an optimized way.
+
 ### Delayed jobs
 Delayed jobs can be executed at sometime in the future.
 ```java

--- a/src/main/java/net/greghaines/jesque/client/AbstractClient.java
+++ b/src/main/java/net/greghaines/jesque/client/AbstractClient.java
@@ -15,16 +15,20 @@
  */
 package net.greghaines.jesque.client;
 
-import static net.greghaines.jesque.utils.ResqueConstants.QUEUE;
-import static net.greghaines.jesque.utils.ResqueConstants.QUEUES;
-
 import net.greghaines.jesque.Config;
 import net.greghaines.jesque.Job;
 import net.greghaines.jesque.json.ObjectMapperFactory;
 import net.greghaines.jesque.utils.JedisUtils;
 import net.greghaines.jesque.utils.JesqueUtils;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Pipeline;
 import redis.clients.jedis.Transaction;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static net.greghaines.jesque.utils.ResqueConstants.QUEUE;
+import static net.greghaines.jesque.utils.ResqueConstants.QUEUES;
 
 /**
  * Common logic for Client implementations.
@@ -86,6 +90,30 @@ public abstract class AbstractClient implements Client {
      * {@inheritDoc}
      */
     @Override
+    public void batchEnqueue(String queue, List<Job> jobs) {
+        if (jobs == null) {
+            throw new IllegalArgumentException("job list must not be null");
+        }
+        for (Job job : jobs) {
+            validateArguments(queue, job);
+        }
+        List<String> serializedJobs = new ArrayList<>(jobs.size());
+        try {
+            for (Job job : jobs) {
+                serializedJobs.add(ObjectMapperFactory.get().writeValueAsString(job));
+            }
+            doBatchEnqueue(queue, serializedJobs);
+        } catch (RuntimeException re) {
+            throw re;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void priorityEnqueue(final String queue, final Job job) {
         validateArguments(queue, job);
         try {
@@ -133,6 +161,18 @@ public abstract class AbstractClient implements Client {
     protected abstract void doEnqueue(String queue, String msg) throws Exception;
 
     /**
+     * Actually enqueue the serialized jobs.
+     * 
+     * @param queue
+     *            the queue to add the Jobs to
+     * @param msgs
+     *            the serialized Jobs
+     * @throws Exception
+     *             in case something goes wrong
+     */
+    protected abstract void doBatchEnqueue(String queue, List<String> msgs) throws Exception;
+
+    /**
      * Actually enqueue the serialized job with high priority.
      * 
      * @param queue
@@ -176,6 +216,27 @@ public abstract class AbstractClient implements Client {
     public static void doEnqueue(final Jedis jedis, final String namespace, final String queue, final String jobJson) {
         jedis.sadd(JesqueUtils.createKey(namespace, QUEUES), queue);
         jedis.rpush(JesqueUtils.createKey(namespace, QUEUE, queue), jobJson);
+    }
+
+    /**
+     * Helper method that encapsulates the minimum logic for adding jobs to a queue.
+     * 
+     * @param jedis
+     *            the connection to Redis
+     * @param namespace
+     *            the Resque namespace
+     * @param queue
+     *            the Resque queue name
+     * @param jobJsons
+     *            a list of jobs serialized as JSON
+     */
+    public static void doBatchEnqueue(final Jedis jedis, final String namespace, final String queue, final List<String> jobJsons) {
+        Pipeline pipelined = jedis.pipelined();
+        pipelined.sadd(JesqueUtils.createKey(namespace, QUEUES), queue);
+        for (String jobJson : jobJsons) {
+            pipelined.rpush(JesqueUtils.createKey(namespace, QUEUE, queue), jobJson);
+        }
+        pipelined.sync();
     }
 
     /**

--- a/src/main/java/net/greghaines/jesque/client/AbstractClient.java
+++ b/src/main/java/net/greghaines/jesque/client/AbstractClient.java
@@ -94,8 +94,9 @@ public abstract class AbstractClient implements Client {
         if (jobs == null) {
             throw new IllegalArgumentException("job list must not be null");
         }
+        validateQueue(queue);
         for (Job job : jobs) {
-            validateArguments(queue, job);
+            validateJob(job);
         }
         List<String> serializedJobs = new ArrayList<>(jobs.size());
         try {
@@ -448,9 +449,11 @@ public abstract class AbstractClient implements Client {
     }
 
     private static void validateArguments(final String queue, final Job job) {
-        if (queue == null || "".equals(queue)) {
-            throw new IllegalArgumentException("queue must not be null or empty: " + queue);
-        }
+        validateQueue(queue);
+        validateJob(job);
+    }
+
+    private static void validateJob(Job job) {
         if (job == null) {
             throw new IllegalArgumentException("job must not be null");
         }
@@ -459,8 +462,18 @@ public abstract class AbstractClient implements Client {
         }
     }
 
+    private static void validateQueue(String queue) {
+        if (queue == null || "".equals(queue)) {
+            throw new IllegalArgumentException("queue must not be null or empty: " + queue);
+        }
+    }
+
     private static void validateArguments(final String queue, final Job job, final long future) {
         validateArguments(queue, job);
+        validateFuture(future);
+    }
+
+    private static void validateFuture(long future) {
         if (System.currentTimeMillis() > future) {
             throw new IllegalArgumentException("future must be after current time");
         }
@@ -468,6 +481,10 @@ public abstract class AbstractClient implements Client {
 
     private static void validateArguments(final String queue, final Job job, final long future, final long frequency) {
         validateArguments(queue, job, future);
+        validateFrequency(frequency);
+    }
+
+    private static void validateFrequency(long frequency) {
         if (frequency < 1) {
             throw new IllegalArgumentException("frequency must be greater than one second");
         }

--- a/src/main/java/net/greghaines/jesque/client/Client.java
+++ b/src/main/java/net/greghaines/jesque/client/Client.java
@@ -17,6 +17,8 @@ package net.greghaines.jesque.client;
 
 import net.greghaines.jesque.Job;
 
+import java.util.List;
+
 /**
  * A Client allows Jobs to be enqueued for execution by Workers.
  * 
@@ -36,6 +38,20 @@ public interface Client {
      *             if the queue is null or empty or if the job is null
      */
     void enqueue(String queue, Job job);
+
+    /**
+     * Queues jobs in a given queue to be run. It uses Redis Pipelining (https://redis.io/topics/pipelining).
+     * Check out the "Important Note" here: https://redis.io/topics/pipelining#redis-pipelining. => Consider splitting
+     * long lists of jobs into chunks of 10,000 or so.
+     * 
+     * @param queue
+     *            the queue to add the Job to
+     * @param jobs
+     *            the jobs to be enqueued
+     * @throws IllegalArgumentException
+     *             if the queue is null or empty or if the list of jobs is null
+     */
+    void batchEnqueue(String queue, List<Job> jobs);
 
     /**
      * Queues a job with high priority in a given queue to be run.

--- a/src/main/java/net/greghaines/jesque/client/ClientImpl.java
+++ b/src/main/java/net/greghaines/jesque/client/ClientImpl.java
@@ -15,6 +15,7 @@
  */
 package net.greghaines.jesque.client;
 
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -107,6 +108,15 @@ public class ClientImpl extends AbstractClient {
     protected void doEnqueue(final String queue, final String jobJson) {
         ensureJedisConnection();
         doEnqueue(this.jedis, getNamespace(), queue, jobJson);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void doBatchEnqueue(final String queue, final List<String> jobsJson) {
+        ensureJedisConnection();
+        doBatchEnqueue(this.jedis, getNamespace(), queue, jobsJson);
     }
 
     /**

--- a/src/main/java/net/greghaines/jesque/client/ClientPoolImpl.java
+++ b/src/main/java/net/greghaines/jesque/client/ClientPoolImpl.java
@@ -21,6 +21,8 @@ import net.greghaines.jesque.utils.PoolUtils.PoolWork;
 import redis.clients.jedis.Jedis;
 import redis.clients.util.Pool;
 
+import java.util.List;
+
 /**
  * A Client implementation that gets its connection to Redis from a connection
  * pool.
@@ -60,6 +62,20 @@ public class ClientPoolImpl extends AbstractClient {
             @Override
             public Void doWork(final Jedis jedis) {
                 doEnqueue(jedis, getNamespace(), queue, jobJson);
+                return null;
+            }
+        });
+    }
+
+    @Override
+    protected void doBatchEnqueue(final String queue, final List<String> jobsJson) throws Exception {
+        PoolUtils.doWorkInPool(this.jedisPool, new PoolWork<Jedis, Void>() {
+            /**
+             * {@inheritDoc}
+             */
+            @Override
+            public Void doWork(final Jedis jedis) {
+                doBatchEnqueue(jedis, getNamespace(), queue, jobsJson);
                 return null;
             }
         });

--- a/src/test/java/net/greghaines/jesque/Issue56Test.java
+++ b/src/test/java/net/greghaines/jesque/Issue56Test.java
@@ -43,7 +43,7 @@ public class Issue56Test {
     }
 
     public static void enqueue() {
-        final long future = System.currentTimeMillis() + 5;
+        final long future = System.currentTimeMillis() + 500;
         final Job job = new Job(TestAction.class.getSimpleName());
         CLIENT.delayedEnqueue(QUEUE, job, future);
     }

--- a/src/test/java/net/greghaines/jesque/TestUtils.java
+++ b/src/test/java/net/greghaines/jesque/TestUtils.java
@@ -83,6 +83,15 @@ public final class TestUtils {
         }
     }
 
+    public static void batchEnqueueJobs(String queue, List<Job> jobs, Config config) {
+        final Client client = new ClientImpl(config);
+        try {
+            client.batchEnqueue(queue, jobs);
+        } finally {
+            client.end();
+        }
+    }
+
     public static void stopWorker(final JobExecutor worker, final Thread workerThread) {
         stopWorker(worker, workerThread, false);
     }


### PR DESCRIPTION
This change allows enqueueing a list of jobs with higher performance than one-by-one invoking the existing `client.enqueue()` method. It therefore uses Redis Pipelining: https://redis.io/topics/pipelining.

I decided against supporting splitting the list of jobs into chunks of e.g. 10,000 jobs, which is recommended by Redis ('Important Note' at https://redis.io/topics/pipelining#redis-pipelining). I mentioned this in the JavaDoc and left it to the client of this method to keep the library simple. Some clients might want to ignore this and I wanted to leave it up to the user.

This change also includes a bit of refactoring of the `validate` methods to be able to validate the queue name parameter independently of a job parameter.

Closes https://github.com/gresrun/jesque/issues/123